### PR TITLE
Update homeassistant.yaml.j2

### DIFF
--- a/ansible/roles/docker-site/templates/homeassistant.yaml.j2
+++ b/ansible/roles/docker-site/templates/homeassistant.yaml.j2
@@ -79,7 +79,7 @@ services:
     image: "influxdb:1.8"
     restart: unless-stopped
     ports:
-      - 8086
+      - 8086:8086
     volumes:
       - influx-data:/var/lib/influxdb
     labels:


### PR DESCRIPTION
Enabling influxdb to have access outside of the cluster